### PR TITLE
Allow arbitrary object paths for fetch-on-update keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 .module-cache
 
 /lib
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const UserProfileFetcher = fetchOnUpdate(({ username, fetchUser }) => {
 }, "username", "fetchUser")(UserProfile);
 ```
 
-Now, the update function will only run if the specific `username` or `fetchUser` props change.
+Now, the update function will only run if the specific `username` or `fetchUser` props change. You can use object paths of arbitrary length here: e.g. `user.username`; in which case the `fn` will only run if the `username` field on `user` changes.
 
 ### `createAjaxAction(action, getPromise)`
 

--- a/package.json
+++ b/package.json
@@ -22,16 +22,14 @@
     "prepublish": "npm run lint && npm run compile"
   },
   "dependencies": {
-    "lodash.camelcase": "4.x",
-    "lodash.memoize": "4.x",
-    "lodash.upperfirst": "4.x",
+    "lodash": "4.x",
     "reselect": "2.x",
     "seamless-immutable": "6.x",
     "shallowequal": "0.2.x"
   },
   "peerDependencies": {
-    "redux": "3.x",
-    "react": ">= 0.14"
+    "react": ">= 0.14",
+    "redux": "3.x"
   },
   "devDependencies": {
     "babel-cli": "6.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-rsi",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Utility & helper functions for reducing the boilerplate necessary when creating redux reducers & actions",
   "main": "lib/index.js",
   "author": "Archon Information Systems",

--- a/src/convert-action-type.js
+++ b/src/convert-action-type.js
@@ -1,5 +1,4 @@
-import camelCase from "lodash.camelcase";
-import upperFirst from "lodash.upperfirst";
+import { camelCase, upperFirst } from "lodash";
 
 export default function(type) {
 	return `on${upperFirst(camelCase(type))}`;

--- a/src/create-selector.js
+++ b/src/create-selector.js
@@ -1,7 +1,7 @@
 // https://github.com/reactjs/reselect#use-memoize-function-from-lodash-for-an-unbounded-cache
 
 import { createSelectorCreator } from "reselect";
-import memoize from "lodash.memoize";
+import { memoize } from "lodash";
 
 const hashFn = (...args) => args.reduce(
 	(acc, val) => `${acc}-${JSON.stringify(val)}`,

--- a/src/fetch-on-update.jsx
+++ b/src/fetch-on-update.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { get, set } from "lodash";
+import { get } from "lodash";
 import shallowEqual from "shallowequal";
 
 export default function fetchOnUpdate(fn, ...keys) {
@@ -26,17 +26,16 @@ export default function fetchOnUpdate(fn, ...keys) {
 function mapParams (paramKeys, params) {
 	if (paramKeys.length < 1) return params;
 
-	const result = {};
-
-	paramKeys.forEach(path => {
+	return paramKeys.reduce((result, path) => {
 		const value = get(params, path);
 
 		// move any nested paths to the root of the result
 		// for the purpose of doing a shallow comparison
-		path = path.replace(".", "_");
+		const shallowKey = path.replace(".", "_");
 
-		set(result, path, value);
+		return {
+			...result,
+			[shallowKey]: value
+		};
 	});
-
-	return result;
 }

--- a/src/fetch-on-update.jsx
+++ b/src/fetch-on-update.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { get, set } from "lodash";
 import shallowEqual from "shallowequal";
 
 export default function fetchOnUpdate(fn, ...keys) {
@@ -25,7 +26,17 @@ export default function fetchOnUpdate(fn, ...keys) {
 function mapParams (paramKeys, params) {
 	if (paramKeys.length < 1) return params;
 
-	return paramKeys.reduce((acc, key) => {
-		return Object.assign({}, acc, { [key]: params[key] });
-	}, {});
+	const result = {};
+
+	paramKeys.forEach(path => {
+		const value = get(params, path);
+
+		// move any nested paths to the root of the result
+		// for the purpose of doing a shallow comparison
+		path = path.replace(".", "_");
+
+		set(result, path, value);
+	});
+
+	return result;
 }


### PR DESCRIPTION
The `fetch-on-update` utility now allows arbitrary object paths for the keys that it will evaluate.

So, I can now do this:

```jsx
const Fetcher = fetchOnUpdate(({ fetchPurchasesByAuction, auction: { lotNumber } }) => {
	if (lotNumber) {
		fetchPurchasesByAuction(lotNumber);
	}
}, "auction.lotNumber")(ComponentThatIWantToWrap);
```

and it will only run the `fetch` function if the `lotNumber` on `auction` changes. Previously that would not work and it had to be dependent on `auction` which, if it errored, would cause it to get in an infinite loop of fetching and erroring.