### PR TITLE
Use babel-plugin-lodash in build step

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
 	"presets": ["es2015", "react", "stage-2"],
-	"plugins": ["transform-export-extensions"]
+	"plugins": ["lodash", "transform-export-extensions"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-rsi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Utility & helper functions for reducing the boilerplate necessary when creating redux reducers & actions",
   "main": "lib/index.js",
   "author": "Archon Information Systems",
@@ -34,6 +34,7 @@
   "devDependencies": {
     "babel-cli": "6.x",
     "babel-core": "6.x",
+    "babel-plugin-lodash": "3.x",
     "babel-plugin-transform-export-extensions": "6.x",
     "babel-preset-es2015": "6.x",
     "babel-preset-react": "6.x",


### PR DESCRIPTION
Realizing from the comments on 0e7d3d9327c9cf5785e828cb17b3349ae12d5ecf that we need to include this as a build step in this repo. I previously though we needed to include it in the build steps of consuming applications.

This brings the module size back down after importing full lodash.