### PR TITLE
Add asyncifyAction utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install redux-rsi --save
 1. [`createReducer`](#createreducerinitialstate-handlers)
 2. [`fetchOnUpdate`](#fetchonupdatefn-keys)
 3. [`createAjaxAction`](#createajaxactionaction-getpromise)
+3. [`asyncifyAction`](#asyncifyactionaction)
 4. [`mergeWithCurrent`](#mergewithcurrentstate-key-data-initfn)
 
 ### `createReducer(initialState, handlers)`
@@ -196,6 +197,39 @@ export function fetchUser(username) {
 	}, () => api.fetchUser(username));
 }
 ```
+
+### `asyncifyAction(action)`
+
+This will "asyncify" an action by returning to you the _completed_ & _failed_ action types by appending `_COMPLETED` and `_FAILED` to your original action type.
+
+```js
+import { asyncifyAction } from "redux-rsi";
+
+const fetchActions = asyncifyAction({
+	type: "USERS_FETCH",
+	payload: username
+});
+
+export function fetchUser(username) {
+	// assuming using redux-thunk here
+	return dispatch => {
+		// dispatch the original action USERS_FETCH
+		dispatch(fetchActions.request);
+
+		// simulate an ajax request & dispatch USERS_FETCH_COMPLETED after 2 seconds
+		setTimeout(fetchActions.completed({ hello: "from the server" }), 2000);
+		
+		// ...OR...
+
+		// simulate a failed ajax request & dispatch USERS_FETCH_FAILED after 2 seconds
+		setTimeout(fetchActions.failed({ message: "error from the server" }), 2000);
+	};
+}
+```
+
+The _failed_ & _completed_ actions have the payload from the original action set as their `meta` (see [Flux Standard Actions](https://github.com/acdlite/flux-standard-action)).
+
+This is what [`createAjaxAction`](#createajaxactionaction-getpromise) uses internally.
 
 ### `mergeWithCurrent(state, key, data, [initFn])`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-rsi",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Utility & helper functions for reducing the boilerplate necessary when creating redux reducers & actions",
   "main": "lib/index.js",
   "author": "Archon Information Systems",

--- a/src/asyncify-action.js
+++ b/src/asyncify-action.js
@@ -1,0 +1,16 @@
+export default function asyncifyAction(action) {
+	return {
+		request: action,
+		completed: response => ({
+			type: `${action.type}_COMPLETED`,
+			payload: response,
+			meta: action.payload // the original payload
+		}),
+		failed: err => ({
+			type: `${action.type}_FAILED`,
+			payload: err,
+			meta: action.payload, // the original payload
+			error: true
+		})
+	};
+}

--- a/src/create-ajax-action.js
+++ b/src/create-ajax-action.js
@@ -1,34 +1,21 @@
-export default function createAjaxAction(action, getPromise) {
+import asyncify from "./asyncify-action";
+
+export default function createAjaxAction(actionTemplate, getPromise) {
 	return (dispatch, getState) => {
 		const promise = getPromise(getState);
 		if (!promise) return;
 
-		dispatch(action);
+		const action = asyncify(actionTemplate);
+
+		dispatch(action.request);
 
 		promise.then(response => {
 			// setTimeout here for dispatching success so that any errors that occur during the dispatch are not
 			// handled & potentially swallowed by the promise's catch. A failure should be dispatched only if the
 			// AJAX request iteslf fails, not any error that occurs as a result of processing the AJAX request.
-			setTimeout(() => dispatch(completed(response, action.payload)), 0);
+			setTimeout(() => dispatch(action.completed(response)), 0);
 		}, err => {
-			setTimeout(() => dispatch(failed(err, action.payload)), 0);
+			setTimeout(() => dispatch(action.failed(err)), 0);
 		});
 	};
-
-	function completed(payload, meta) {
-		return {
-			type: `${action.type}_COMPLETED`,
-			payload,
-			meta
-		};
-	}
-
-	function failed(payload, meta) {
-		return {
-			type: `${action.type}_FAILED`,
-			payload,
-			meta,
-			error: true
-		};
-	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export createReducer from "./create-reducer";
 export fetchOnUpdate from "./fetch-on-update";
+export asyncifyAction from "./asyncify-action";
 export createAjaxAction from "./create-ajax-action";
 export createSelector from "./create-selector";
 export mergeWithCurrent from "./merge-with-current";


### PR DESCRIPTION
Need to be able to use the auto-actions from `createAjaxAction` without any of the `createAjaxAction` stuff. This is a less invasive way to provide hooks to accomplish the same thing #4 was trying to accomplish.