### PR TITLE
Add option to disable fetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-rsi",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Utility & helper functions for reducing the boilerplate necessary when creating redux reducers & actions",
   "main": "lib/index.js",
   "author": "Archon Information Systems",

--- a/src/fetch-on-update.jsx
+++ b/src/fetch-on-update.jsx
@@ -5,14 +5,16 @@ import shallowEqual from "shallowequal";
 export default function fetchOnUpdate(fn, ...keys) {
 	return DecoratedComponent => class FetchOnUpdateDecorator extends Component {
 		componentWillMount() {
-			fn(this.props);
+			if (!this.props.disableFetch) {
+				fn(this.props);
+			}
 		}
 
 		componentDidUpdate (prevProps) {
 			const params = mapParams(keys, this.props);
 			const prevParams = mapParams(keys, prevProps);
 
-			if (!shallowEqual(params, prevParams)) {
+			if (!shallowEqual(params, prevParams) && !this.props.disableFetch) {
 				fn(this.props);
 			}
 		}


### PR DESCRIPTION
For components wrapped with `fetch-on-update` decorator, it will now respect the `disableFetch` option.

This is part of the fix to reduce the chattiness of the auctioneer search page reported as slowness during the last sale.