### PR TITLE
Support webpack 2 tree shaking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,16 @@
 {
-	"presets": ["es2015", "react", "stage-2"],
-	"plugins": ["lodash", "transform-export-extensions"]
+	"presets": [
+		["es2015", { "modules": false }],
+		"react",
+		"stage-2"
+	],
+	"plugins": [
+		"lodash",
+		"transform-export-extensions"
+	],
+	"env": {
+		"cjs": {
+			"presets": ["es2015", "react", "stage-2"]
+		}
+	}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ npm-debug.log
 .module-cache
 
 /lib
+/es
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "redux-rsi",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Utility & helper functions for reducing the boilerplate necessary when creating redux reducers & actions",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "author": "Archon Information Systems",
   "license": "MIT",
   "repository": {
@@ -16,9 +17,10 @@
     "reducers"
   ],
   "scripts": {
-    "compile": "rimraf lib && babel -d lib src",
+    "compile-cjs": "rimraf lib && cross-env BABEL_ENV=cjs babel src -d lib",
+    "compile-es": "rimraf es && babel src -d es",
+    "compile": "npm run compile-cjs && npm run compile-es",
     "lint": "eslint src --ext=js,jsx",
-    "lint-fix": "eslint src --ext=js,jsx --fix",
     "prepublish": "npm run lint && npm run compile"
   },
   "dependencies": {
@@ -39,6 +41,7 @@
     "babel-preset-es2015": "6.x",
     "babel-preset-react": "6.x",
     "babel-preset-stage-2": "6.x",
+    "cross-env": "3.x",
     "eslint": "3.x",
     "eslint-config-civicsource": "1.x",
     "rimraf": "2.x"


### PR DESCRIPTION
A build with import/exports retained is now built into the es folder which webpack 2 can use for tree shaking. Webpack 2 looks for the `module` field in `package.json`.