### PR TITLE
Fixing broken fetchOnUpdate

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+	"version": "0.2.0",
+	"configurations": [{
+		"name": "Attach to Mocha tests",
+		"type": "node",
+		"request": "attach",
+		"port": 5858,
+		"sourceMaps": true
+	}]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.insertSpaces": false,
+    "editor.detectIndentation": true
+}

--- a/README.md
+++ b/README.md
@@ -279,3 +279,35 @@ export default createReducer(Immutable({}), {
 ```
 
 The above two examples are equivalent. The `initFn` will receive the state `key` as its only argument.
+
+## Contributing
+
+### Linting
+
+To run the linter:
+
+```
+npm run lint
+```
+
+and to automatically fix fixable errors:
+
+```
+npm run lint -- --fix
+```
+
+### Testing
+
+The tests are written BDD-style using [Mocha](https://mochajs.org/). To run them locally:
+
+```
+npm test
+```
+
+To debug the tests:
+
+```
+npm test -- --debug-brk
+```
+
+You can then use [Visual Studio Code](http://code.visualstudio.com/) (or whatever other debugger you desire) to debug through the tests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-rsi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Utility & helper functions for reducing the boilerplate necessary when creating redux reducers & actions",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "compile-cjs": "rimraf lib && cross-env BABEL_ENV=cjs babel src -d lib",
     "compile-es": "rimraf es && babel src -d es",
     "compile": "npm run compile-cjs && npm run compile-es",
-    "lint": "eslint src --ext=js,jsx",
-    "prepublish": "npm run lint && npm run compile"
+    "lint": "eslint src test --ext=js,jsx",
+    "test": "cross-env BABEL_ENV=cjs mocha --compilers js:babel-core/register --recursive --require babel-polyfill",
+    "prepublish": "npm test && npm run lint && npm run compile"
   },
   "dependencies": {
     "lodash": "4.x",
@@ -38,12 +39,20 @@
     "babel-core": "6.x",
     "babel-plugin-lodash": "3.x",
     "babel-plugin-transform-export-extensions": "6.x",
+    "babel-polyfill": "6.x",
     "babel-preset-es2015": "6.x",
     "babel-preset-react": "6.x",
     "babel-preset-stage-2": "6.x",
-    "cross-env": "3.x",
+    "chai": "3.x",
+    "cross-env": "^3.2.4",
+    "enzyme": "^2.8.0",
     "eslint": "3.x",
     "eslint-config-civicsource": "1.x",
+    "jsdom": "^9.12.0",
+    "mocha": "3.x",
+    "react": "^15.4.2",
+    "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^15.4.2",
     "rimraf": "2.x"
   }
 }

--- a/src/fetch-on-update.jsx
+++ b/src/fetch-on-update.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { get } from "lodash";
+import { get, set } from "lodash";
 import shallowEqual from "shallowequal";
 
 export default function fetchOnUpdate(fn, ...keys) {
@@ -26,16 +26,17 @@ export default function fetchOnUpdate(fn, ...keys) {
 function mapParams (paramKeys, params) {
 	if (paramKeys.length < 1) return params;
 
-	return paramKeys.reduce((result, path) => {
+	const result = {};
+
+	paramKeys.forEach(path => {
 		const value = get(params, path);
 
 		// move any nested paths to the root of the result
 		// for the purpose of doing a shallow comparison
-		const shallowKey = path.replace(".", "_");
+		path = path.replace(/\./g, "_");
 
-		return {
-			...result,
-			[shallowKey]: value
-		};
+		set(result, path, value);
 	});
+
+	return result;
 }

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,0 +1,3 @@
+env:
+  mocha: true
+  es6: true

--- a/test/behaves-like-browser.js
+++ b/test/behaves-like-browser.js
@@ -1,0 +1,30 @@
+import { jsdom } from "jsdom";
+
+export default function() {
+	// inspired by https://semaphoreci.com/community/tutorials/testing-react-components-with-enzyme-and-mocha
+
+	beforeEach(function() {
+		this.exposedProperties = ["document", "window", "navigator"];
+
+		global.document = jsdom("");
+
+		global.window = global.document.defaultView;
+
+		global.navigator = {
+			userAgent: "node.js"
+		};
+
+		Object.keys(document.defaultView).forEach(property => {
+			if (typeof global[property] === "undefined") {
+				this.exposedProperties.push(property);
+				global[property] = document.defaultView[property];
+			}
+		});
+	});
+
+	afterEach(function() {
+		this.exposedProperties.forEach(property => {
+			delete global[property];
+		});
+	});
+}

--- a/test/fetch-on-update.js
+++ b/test/fetch-on-update.js
@@ -1,0 +1,154 @@
+import { expect } from "chai";
+import behavesLikeBrowser from "./behaves-like-browser";
+
+import React from "react";
+import { mount } from "enzyme";
+
+import { fetchOnUpdate } from "../src";
+
+describe("Fetching on component props update", function() {
+	behavesLikeBrowser();
+
+	const NakedComponent = () => <span>Hello, world</span>;
+
+	describe("when rendering a component without specifying keys", function() {
+		beforeEach(function () {
+			this.callCount = 0;
+
+			this.FetchingComponent = fetchOnUpdate(() => {
+				this.callCount++;
+			})(NakedComponent);
+		});
+
+		describe("for the first time", function() {
+			beforeEach(function () {
+				this.wrapper = mount(<this.FetchingComponent />);
+			});
+
+			it("should call the fetch function", function() {
+				expect(this.callCount).to.equal(1);
+			});
+
+			describe("and then setting arbitrary props on the component", function() {
+				beforeEach(function () {
+					this.wrapper.setProps({ hello: "world" });
+				});
+
+				it("should call the fetch function again", function() {
+					expect(this.callCount).to.equal(2);
+				});
+			});
+		});
+	});
+
+	describe("when rendering a component while specifying keys", function() {
+		beforeEach(function () {
+			this.callCount = 0;
+
+			this.FetchingComponent = fetchOnUpdate(() => {
+				this.callCount++;
+			}, "name", "age")(NakedComponent);
+		});
+
+		describe("for the first time", function() {
+			beforeEach(function () {
+				this.wrapper = mount(<this.FetchingComponent name="Homer Simpson" />);
+			});
+
+			it("should call the fetch function", function() {
+				expect(this.callCount).to.equal(1);
+			});
+
+			describe("and then setting a keyed prop on the component", function() {
+				beforeEach(function () {
+					this.wrapper.setProps({ name: "Marge Simpson" });
+				});
+
+				it("should call the fetch function again", function() {
+					expect(this.callCount).to.equal(2);
+				});
+			});
+
+			describe("and then setting a previously unspecified keyed prop on the component", function() {
+				beforeEach(function () {
+					this.wrapper.setProps({ age: 42 });
+				});
+
+				it("should call the fetch function again", function() {
+					expect(this.callCount).to.equal(2);
+				});
+			});
+
+			describe("and then setting arbitrary props on the component", function() {
+				beforeEach(function () {
+					this.wrapper.setProps({ hello: "world" });
+				});
+
+				it("should not call the fetch function again", function() {
+					expect(this.callCount).to.equal(1);
+				});
+			});
+		});
+	});
+
+	describe("when rendering a component while specifying a deep key", function() {
+		beforeEach(function () {
+			this.callCount = 0;
+
+			this.FetchingComponent = fetchOnUpdate(() => {
+				this.callCount++;
+			}, "user.name.first")(NakedComponent);
+		});
+
+		describe("for the first time", function() {
+			beforeEach(function () {
+				const user = {
+					name: {
+						first: "Homer",
+						last: "Simpson"
+					}
+				};
+
+				this.wrapper = mount(<this.FetchingComponent user={user} />);
+			});
+
+			it("should call the fetch function", function() {
+				expect(this.callCount).to.equal(1);
+			});
+
+			describe("and then setting a keyed nested prop on the component", function() {
+				beforeEach(function () {
+					const user = {
+						name: {
+							first: "Marge",
+							last: "Simpson"
+						}
+					};
+
+					this.wrapper.setProps({ user });
+				});
+
+				it("should call the fetch function again", function() {
+					expect(this.callCount).to.equal(2);
+				});
+			});
+
+			describe("and then setting arbitrary deep props on the component", function() {
+				beforeEach(function () {
+					const user = {
+						name: {
+							first: "Homer",
+							last: "Jenkins"
+						}
+					};
+
+					this.wrapper.setProps({ user });
+				});
+
+				it("should not call the fetch function again", function() {
+					expect(this.callCount).to.equal(1);
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
This fixes a bug introduced in #2 which caused `fetchOnUpdate` to never fire the fetch function when params were changing.

This also fixes a bug where `fetchOnUpdate` would not work correctly with paths nested deeper than 2 levels.

Adding test cases exposing the issues.