### PR TITLE
Update redux dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "seamless-immutable": "6.x"
   },
   "peerDependencies": {
-    "redux": "4.0.0-beta.2"
+    "redux": ">= 3.x < 5"
   },
   "devDependencies": {
     "babel-cli": "6.x",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "seamless-immutable": "6.x"
   },
   "peerDependencies": {
-    "redux": "3.x"
+    "redux": "4.0.0-beta.2"
   },
   "devDependencies": {
     "babel-cli": "6.x",


### PR DESCRIPTION
Updates redux dependency to beta version. This is necessary for react-redux to support lifecycle methods introduced in react 16.3 [[Link](https://github.com/reactjs/react-redux/issues/915)]

Note: As soon as redux releases a stable v4.0 we'll want to update again, and for now release this is a beta version.